### PR TITLE
feat: switch homelab_ops.configure.cloud_init role to enable running specified runcmd commands

### DIFF
--- a/.github/workflows/test-configure.yaml
+++ b/.github/workflows/test-configure.yaml
@@ -53,8 +53,8 @@ jobs:
 
     - name: Install ansible collections
       run: |
-        ansible-galaxy collection install ./block_device/
-        ansible-galaxy collection install ./configure/
+        ansible-galaxy collection install --force ./block_device/
+        ansible-galaxy collection install --force ./configure/
 
     - name: Determine molecule verbosity
       # yamllint disable-line rule:indentation

--- a/.github/workflows/test-raspberry_pi.yaml
+++ b/.github/workflows/test-raspberry_pi.yaml
@@ -53,10 +53,10 @@ jobs:
 
     - name: Install ansible collections
       run: |
-        ansible-galaxy collection install ./raspberry_pi/
-        ansible-galaxy collection install ./block_device/
-        ansible-galaxy collection install ./configure/
-        ansible-galaxy collection install ./archive/
+        ansible-galaxy collection install --force ./raspberry_pi/
+        ansible-galaxy collection install --force ./block_device/
+        ansible-galaxy collection install --force ./configure/
+        ansible-galaxy collection install --force ./archive/
 
     - name: Determine molecule verbosity
       # yamllint disable-line rule:indentation

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,10 @@
     "editor.detectIndentation": false,
     "editor.indentSize": 2
   },
+  "[jinja]": {
+    "editor.formatOnPaste": false,
+    "editor.formatOnSave": false
+  },
   "[json]": {
     "editor.detectIndentation": false,
     "editor.indentSize": 2

--- a/configure/molecule/cloud_init/converge.yml
+++ b/configure/molecule/cloud_init/converge.yml
@@ -13,7 +13,7 @@
     - localhost
     - "{{ data_source_path }}/runcmd/playbook.yaml"
     - -e
-    - "{{ ('\"@' + data_source_path + '/runcmd/playbook-vars.yaml\"') | quote }}"
+    - "{{ ('\"@' + data_source_path + '/runcmd/playbook-vars.yaml\"') }}"
   tasks:
   - name: "Configure cloud init"
     ansible.builtin.include_role:

--- a/configure/molecule/cloud_init/converge.yml
+++ b/configure/molecule/cloud_init/converge.yml
@@ -13,7 +13,7 @@
     - localhost
     - "{{ data_source_path }}/runcmd/playbook.yaml"
     - -e
-    - "{{ ('@' + data_source_path + '/runcmd/playbook-vars.yaml') | quote }}"
+    - "{{ ('\"@' + data_source_path + '/runcmd/playbook-vars.yaml\"') | quote }}"
   tasks:
   - name: "Configure cloud init"
     ansible.builtin.include_role:

--- a/configure/molecule/cloud_init/converge.yml
+++ b/configure/molecule/cloud_init/converge.yml
@@ -3,19 +3,24 @@
   hosts: all
   gather_facts: false
   vars:
-    cloudinit_seed_path: "/mnt/cloudinit"
+    data_source_path: "/mnt/cloudinit"
   tasks:
   - name: "Configure cloud init"
     ansible.builtin.include_role:
       name: homelab_ops.configure.cloud_init
     vars:
       cloudinit:
-        data_source_path: "{{ cloudinit_seed_path }}"
+        data_source_path: "{{ data_source_path }}"
         local_hostname: test-hostname
         instance_id: test-instance
         users:
         - name: test-user
           authorized_keys:
           - ssh-ed25519 AAAABBBBCCCCDDDDEEEEFFFF test-user@email.com
-        ansible_playbook: "playbook.yaml"
-        ansible_vars_file: "vars.yaml"
+        runcmd_commands:
+        - "[timedatectl, set-ntp, 'true']"
+        - "[ANSIBLE_LOCALHOST_WARNING=false, ansible-playbook, -c, local, -i, localhost, {{ data_source_path }}/runcmd/playbook.yaml, -e, @{{ data_source_path }}/runcmd/playbook-vars.yaml]"
+        runcmd_files:
+        - source: "{{ playbook_dir }}/input/playbook.yaml"
+          mode: '0644'
+        - source: "{{ playbook_dir }}/input/playbook-vars.yaml"

--- a/configure/molecule/cloud_init/converge.yml
+++ b/configure/molecule/cloud_init/converge.yml
@@ -4,6 +4,16 @@
   gather_facts: false
   vars:
     data_source_path: "/mnt/cloudinit"
+    ansible_playbook_invoke_cmd:
+    - ANSIBLE_LOCALHOST_WARNING=false
+    - ansible-playbook
+    - -c
+    - local
+    - -i
+    - localhost
+    - "{{ data_source_path }}/runcmd/playbook.yaml"
+    - -e
+    - "{{ ('@' + data_source_path + '/runcmd/playbook-vars.yaml') | quote }}"
   tasks:
   - name: "Configure cloud init"
     ansible.builtin.include_role:
@@ -19,7 +29,7 @@
           - ssh-ed25519 AAAABBBBCCCCDDDDEEEEFFFF test-user@email.com
         runcmd_commands:
         - "[timedatectl, set-ntp, 'true']"
-        - "[ANSIBLE_LOCALHOST_WARNING=false, ansible-playbook, -c, local, -i, localhost, {{ data_source_path }}/runcmd/playbook.yaml, -e, @{{ data_source_path }}/runcmd/playbook-vars.yaml]"
+        - "[{{ ansible_playbook_invoke_cmd | join(', ') }}]"
         runcmd_files:
         - source: "{{ playbook_dir }}/input/playbook.yaml"
           mode: '0644'

--- a/configure/molecule/cloud_init/input/playbook-vars.yaml
+++ b/configure/molecule/cloud_init/input/playbook-vars.yaml
@@ -1,0 +1,5 @@
+---
+# example file with variables for the ansible-playbook
+a: b
+c: d
+e: f

--- a/configure/molecule/cloud_init/input/playbook.yaml
+++ b/configure/molecule/cloud_init/input/playbook.yaml
@@ -1,0 +1,10 @@
+---
+- name: Running example playbook from cloud-init's runcmd stage
+  hosts: localhost
+  become: true
+  gather_facts: true
+
+  tasks:
+  - name: "Hello world"
+    ansible.builtin.debug:
+      msg: "Hello world"

--- a/configure/molecule/cloud_init/prepare.yml
+++ b/configure/molecule/cloud_init/prepare.yml
@@ -3,11 +3,11 @@
   hosts: all
   gather_facts: false
   vars:
-    cloudinit_seed_path: "/mnt/cloudinit"
+    data_source_path: "/mnt/cloudinit"
   tasks:
   - name: "Create needed directories"
     ansible.builtin.file:
-      path: "{{ cloudinit_seed_path }}"
+      path: "{{ data_source_path }}"
       owner: root
       group: root
       mode: '0750'

--- a/configure/molecule/cloud_init/verify.yml
+++ b/configure/molecule/cloud_init/verify.yml
@@ -15,10 +15,16 @@
       - users
       - hostname
       - runcmd
+      - ssh_deletekeys
+      - ssh_genkeytypes
+      - ssh_pwauth
+      - ssh
+      - growpart
+      - resize_rootfs
       meta-data:
       - local-hostname
       - instance-id
-    required_user_keys:
+    required_ssh_user_keys:
     - name
     - groups
     - sudo
@@ -85,9 +91,8 @@
   - name: "Assert that the required ssh-user keys are present"
     ansible.builtin.assert:
       that: item in generated_datasource['user-data'].users[0]
-    loop: "{{ required_user_keys'] }}"
+    loop: "{{ required_ssh_user_keys }}"
 
   - name: "Assert that expected number of run commands are present"
     ansible.builtin.assert:
       that: (generated_datasource['user-data'].runcmd|length) == expected_runcmd_count
-    loop: "{{ required_user_keys'] }}"

--- a/configure/molecule/cloud_init/verify.yml
+++ b/configure/molecule/cloud_init/verify.yml
@@ -44,14 +44,19 @@
       msg: "{{ item['content'] | b64decode }}"
     loop: "{{ cloudinit_generated.results }}"
 
-  - name: "Parse userdata and metadata file content"
+  - name: "Parse generated cloud-init datasource file content"
     when: (item['item'] | basename) is in ['user-data', 'meta-data']
     ansible.builtin.set_fact:
-      generated_datasource: "{{ generated_datasource | default() | combine({ds_name: parsed_value}) }}"
+      generated_datasource: "{{ generated_datasource | default({}) | combine({ds_name: parsed_value}) }}"
     vars:
       ds_name: "{{ item['item'] | basename }}"
       parsed_value: "{{ item['content'] | b64decode | from_yaml }}"
     loop: "{{ cloudinit_generated.results }}"
+
+  - name: "Display generated cloud init datasource file"
+    ansible.builtin.debug:
+      msg: "{{ generated_datasource[item] }}"
+    loop: "{{ generated_datasource }}"
 
   - name: "Assert that the required user-data keys are present"
     ansible.builtin.assert:

--- a/configure/molecule/cloud_init/verify.yml
+++ b/configure/molecule/cloud_init/verify.yml
@@ -40,6 +40,8 @@
       fail_msg: "{{ item.item }} does NOT exist at expected location"
       success_msg: "{{ item.item }} has been generated"
     loop: "{{ cloudinit_stat.results }}"
+    loop_control:
+      label: "{{ item.item }}"
 
   - name: "Read generated cloudinit files"
     ansible.builtin.slurp:
@@ -49,22 +51,26 @@
 
   - name: "Display generated cloud init file"
     ansible.builtin.debug:
-      msg: "{{ item['content'] | b64decode }}"
+      msg: "{{ item.content | b64decode }}"
     loop: "{{ cloudinit_generated.results }}"
+    loop_control:
+      label: "{{ item.item }}"
 
   - name: "Parse generated cloud-init datasource file content"
-    when: (item['item'] | basename) is in ['user-data', 'meta-data']
+    when: (item.item|basename) is in ['user-data', 'meta-data']
     ansible.builtin.set_fact:
       generated_datasource: "{{ generated_datasource | default({}) | combine({ds_name: parsed_value}) }}"
     vars:
-      ds_name: "{{ item['item'] | basename }}"
-      parsed_value: "{{ item['content'] | b64decode | from_yaml }}"
+      ds_name: "{{ item.item | basename }}"
+      parsed_value: "{{ item.content | b64decode | from_yaml }}"
     loop: "{{ cloudinit_generated.results }}"
+    loop_control:
+      label: "{{ item.item }}"
 
   - name: "Display generated cloud init datasource file"
     ansible.builtin.debug:
       msg: "{{ generated_datasource[item] }}"
-    loop: "{{ generated_datasource }}"
+    loop: "{{ generated_datasource.keys() }}"
 
   - name: "Assert that required user-data keys are present"
     ansible.builtin.assert:

--- a/configure/molecule/cloud_init/verify.yml
+++ b/configure/molecule/cloud_init/verify.yml
@@ -3,11 +3,21 @@
   hosts: all
   gather_facts: false
   vars:
-    cloudinit_seed_path: "/mnt/cloudinit"
+    data_source_path: "/mnt/cloudinit"
     cloud_init_files:
-    - "{{ cloudinit_seed_path }}/user-data"
-    - "{{ cloudinit_seed_path }}/meta-data"
-    - "{{ cloudinit_seed_path }}/vendor-data"
+    - "{{ data_source_path }}/user-data"
+    - "{{ data_source_path }}/meta-data"
+    - "{{ data_source_path }}/vendor-data"
+    - "{{ data_source_path }}/runcmd/playbook.yaml"
+    - "{{ data_source_path }}/runcmd/playbook-vars.yaml"
+    required_datasource_keys:
+      user-data:
+      - users
+      - hostname
+      - runcmd
+      meta-data:
+      - local-hostname
+      - instance-id
   tasks:
   - name: Stat for generated cloud_init files
     ansible.builtin.stat:
@@ -33,3 +43,22 @@
     ansible.builtin.debug:
       msg: "{{ item['content'] | b64decode }}"
     loop: "{{ cloudinit_generated.results }}"
+
+  - name: "Parse userdata and metadata file content"
+    when: (item['item'] | basename) is in ['user-data', 'meta-data']
+    ansible.builtin.set_fact:
+      generated_datasource: "{{ generated_datasource | default() | combine({ds_name: parsed_value} }}"
+    vars:
+      ds_name: "{{ item['item'] | basename }}"
+      parsed_value: "{{ item['content'] | b64decode | from_yaml }}"
+    loop: "{{ cloudinit_generated.results }}"
+
+  - name: "Assert that the required user-data keys are present"
+    ansible.builtin.assert:
+      that: item in generated_datasource['user-data']
+    loop: "{{ required_datasource_keys['user-data'] }}"
+
+  - name: "Assert that the required meta-data keys are present"
+    ansible.builtin.assert:
+      that: item in generated_datasource['meta-data']
+    loop: "{{ required_datasource_keys['meta-data'] }}"

--- a/configure/molecule/cloud_init/verify.yml
+++ b/configure/molecule/cloud_init/verify.yml
@@ -18,6 +18,14 @@
       meta-data:
       - local-hostname
       - instance-id
+    required_user_keys:
+    - name
+    - groups
+    - sudo
+    - ssh_authorized_keys
+    - lock_passwd
+    - shell
+    expected_runcmd_count: 2
   tasks:
   - name: Stat for generated cloud_init files
     ansible.builtin.stat:
@@ -58,12 +66,22 @@
       msg: "{{ generated_datasource[item] }}"
     loop: "{{ generated_datasource }}"
 
-  - name: "Assert that the required user-data keys are present"
+  - name: "Assert that required user-data keys are present"
     ansible.builtin.assert:
       that: item in generated_datasource['user-data']
     loop: "{{ required_datasource_keys['user-data'] }}"
 
-  - name: "Assert that the required meta-data keys are present"
+  - name: "Assert that required meta-data keys are present"
     ansible.builtin.assert:
       that: item in generated_datasource['meta-data']
     loop: "{{ required_datasource_keys['meta-data'] }}"
+
+  - name: "Assert that the required ssh-user keys are present"
+    ansible.builtin.assert:
+      that: item in generated_datasource['user-data'].users[0]
+    loop: "{{ required_user_keys'] }}"
+
+  - name: "Assert that expected number of run commands are present"
+    ansible.builtin.assert:
+      that: (generated_datasource['user-data'].runcmd|length) == expected_runcmd_count
+    loop: "{{ required_user_keys'] }}"

--- a/configure/molecule/cloud_init/verify.yml
+++ b/configure/molecule/cloud_init/verify.yml
@@ -28,7 +28,7 @@
   - name: Assert that cloudinit exists at destination
     ansible.builtin.assert:
       that:
-      - "{{ item.stat.exists }}"
+      - item.stat.exists
       fail_msg: "{{ item.item }} does NOT exist at expected location"
       success_msg: "{{ item.item }} has been generated"
     loop: "{{ cloudinit_stat.results }}"
@@ -47,7 +47,7 @@
   - name: "Parse userdata and metadata file content"
     when: (item['item'] | basename) is in ['user-data', 'meta-data']
     ansible.builtin.set_fact:
-      generated_datasource: "{{ generated_datasource | default() | combine({ds_name: parsed_value} }}"
+      generated_datasource: "{{ generated_datasource | default() | combine({ds_name: parsed_value}) }}"
     vars:
       ds_name: "{{ item['item'] | basename }}"
       parsed_value: "{{ item['content'] | b64decode | from_yaml }}"

--- a/configure/roles/cloud_init/README.md
+++ b/configure/roles/cloud_init/README.md
@@ -1,11 +1,11 @@
 homelab_ops.configure.cloud_init
 ================================
 
-Create userdata and other cloud-init configuration files within the specified location. Created userdata configuration does the following:
+Create userdata and other cloud-init configuration files within the specified datasource location. Created userdata configuration does the following:
 - creates a user who can ssh in using the specified authorized key
 - sets hostname and cloud-init instance-id to specified values
-- configures cloud-init to update time using ntp on first boot
-- configures cloud-init to run given ansible playbook on first boot with given ansible vars file (playbook and vars file must be added separately).
+- configures cloud-init to run the specified `cloudinit.runcmd_commands` during the runcmd stage
+  - any files needed for this can be specified under `cloudinit.runcmd_files` to be placed within the datasource.
 
 Requirements
 ------------

--- a/configure/roles/cloud_init/tasks/main.yaml
+++ b/configure/roles/cloud_init/tasks/main.yaml
@@ -8,6 +8,24 @@
     - cloudinit.instance_id is defined
     - cloudinit.users is defined and cloudinit.users|length > 0
 
+- name: "Create cloud-init runcmd files directory"
+  when: cloudinit.runcmd_files is defined and cloudinit.runcmd_files|length > 0
+  ansible.builtin.file:
+    path: "{{ cloudinit.data_source_path }}/runcmd"
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+
+- name: "Add needed files for cloud-init runcmd commands"
+  ansible.builtin.copy:
+    src: "{{ item.source }}"
+    dest: "{{ cloudinit.data_source_path }}/runcmd/{{ item.source | basename }}"
+    owner: root
+    group: root
+    mode: "{{ item.mode | default('0600') }}"
+  loop: "{{ cloudinit.runcmd_files }}"
+
 - name: "Create configuration"
   ansible.builtin.include_tasks: configure.yaml
   loop:

--- a/configure/roles/cloud_init/templates/user-data.j2
+++ b/configure/roles/cloud_init/templates/user-data.j2
@@ -23,7 +23,7 @@ users:
 {% endfor %}
 
 growpart:
-  mode: off
+  mode: "off"
 resize_rootfs: false
 
 package_update: false

--- a/configure/roles/cloud_init/templates/user-data.j2
+++ b/configure/roles/cloud_init/templates/user-data.j2
@@ -15,9 +15,9 @@ users:
   groups: [sudo]
   sudo: ALL=(ALL) NOPASSWD:ALL
   ssh_authorized_keys:
-  {% for ssh_key in user.authorized_keys -%}
+{% for ssh_key in user.authorized_keys -%}
   - {{ ssh_key }}
-  {% endfor %}
+{% endfor %}
   lock_passwd: true
   shell: /bin/bash
 {% endfor %}

--- a/configure/roles/cloud_init/templates/user-data.j2
+++ b/configure/roles/cloud_init/templates/user-data.j2
@@ -15,7 +15,7 @@ users:
   groups: [sudo]
   sudo: ALL=(ALL) NOPASSWD:ALL
   ssh_authorized_keys:
-{% for ssh_key in user.authorized_keys -%}
+{% for ssh_key in user.authorized_keys %}
   - {{ ssh_key }}
 {% endfor %}
   lock_passwd: true

--- a/configure/roles/cloud_init/templates/user-data.j2
+++ b/configure/roles/cloud_init/templates/user-data.j2
@@ -1,8 +1,15 @@
 #cloud-config
 
+disable_root: true
+ssh_deletekeys: true
+ssh_genkeytypes: [ed25519, rsa]
 ssh_pwauth: false
+ssh:
+  emit_keys_to_console: false
 
+{% if cloudinit.users -%}
 users:
+{% endif %}
 {% for user in cloudinit.users -%}
 - name: {{ user.name }}
   groups: [sudo]
@@ -22,16 +29,16 @@ resize_rootfs: false
 package_update: false
 package_upgrade: false
 
-ssh_deletekeys: true
-ssh_genkeytypes: [ed25519]
-ssh:
-  emit_keys_to_console: false
-
+{% if cloudinit.local_hostname -%}
 hostname: {{ cloudinit.local_hostname }}
+{% endif %}
 manage_etc_hosts: true
 
+timezone: UTC
+
+{% if cloudinit.runcmd_commands -%}
 runcmd:
-- [timedatectl, set-ntp, 'true']
-{% if cloudinit.ansible_playbook %}
-- [ANSIBLE_LOCALHOST_WARNING=false, ansible-playbook, -c, local, -i, localhost, {{ cloudinit.ansible_playbook }}, -e, @{{ cloudinit.ansible_vars_file }}]
 {% endif %}
+{% for runcmd_command in cloudinit.runcmd_commands -%}
+- {{ runcmd_command }}
+{% endfor %}

--- a/configure/roles/cloud_init/templates/user-data.j2
+++ b/configure/roles/cloud_init/templates/user-data.j2
@@ -34,8 +34,6 @@ hostname: {{ cloudinit.local_hostname }}
 {% endif %}
 manage_etc_hosts: true
 
-timezone: UTC
-
 {% if cloudinit.runcmd_commands -%}
 runcmd:
 {% endif %}

--- a/raspberry_pi/molecule/provision/converge.yml
+++ b/raspberry_pi/molecule/provision/converge.yml
@@ -83,8 +83,6 @@
               version: "1.0.1"
               params: []
             collections_requirements_file: "{{ MOLECULE_SCENARIO_DIR }}/input/requirements.yaml"
-            playbook: "{{ MOLECULE_SCENARIO_DIR }}/input/playbook.yaml"
-            vars_file: /root/.secrets/cloudinit-playbook-vars
           ssh_users:
           - name: test-user
             authorized_keys:

--- a/raspberry_pi/roles/provision/tasks/configure-cloudinit.yaml
+++ b/raspberry_pi/roles/provision/tasks/configure-cloudinit.yaml
@@ -18,5 +18,5 @@
       local_hostname: "{{ provision.raspberry_pi.hostname | default(default_hostname) }}"
       instance_id: "{{ provision.raspberry_pi.instance_id | default(default_instance_id) }}"
       users: "{{ provision.cloudinit.ssh_users }}"
-      ansible_playbook: "{{ provision.cloudinit.ansible.playbook }}"
-      ansible_vars_file: "{{ provision.cloudinit.ansible.vars_file }}"
+      runcmd_commands: "{{ provision.cloudinit.runcmd_commands | default([]) }}"
+      runcmd_files: "{{ provision.cloudinit.runcmd_files | default([]) }}"

--- a/raspberry_pi/roles/provision/tasks/main.yaml
+++ b/raspberry_pi/roles/provision/tasks/main.yaml
@@ -17,8 +17,6 @@
     - provision.cloudinit.ssh_users is defined and provision.cloudinit.ssh_users|length > 0
     - provision.cloudinit.ansible.core_version is defined
     - provision.cloudinit.ansible.collections_requirements_file is defined
-    - provision.cloudinit.ansible.playbook is defined
-    - provision.cloudinit.ansible.vars_file is defined
 
 - name: Select block device
   ansible.builtin.import_tasks: select-block-device.yaml

--- a/raspberry_pi/roles/provision/vars/main.yaml
+++ b/raspberry_pi/roles/provision/vars/main.yaml
@@ -4,4 +4,4 @@ partition_defaults: "{{ conventions.raspberry_pi.partitions | combine(convention
 system_root_mount_point: "{{ provision.block_device.root_mount_point.rstrip('/') }}"
 
 default_hostname: "{{ 'rpi-' + provision.raspberry_pi.serial }}"
-default_instance_id: "{{ 'rpi-' + provision.raspberry_pi.serial + '-' + lookup('pipe', 'date +%Y%m%d%H%M%S --utc') }}"
+default_instance_id: "{{ 'rpi-' + provision.raspberry_pi.serial + '-' + lookup('pipe', 'date --utc +%Y%m%d%H%M%S --utc') }}"


### PR DESCRIPTION
- enables specifying any commands to be invoked within runcmd stage of cloudinit (incl. ansible playbooks)
- enables adding any dependent files to the generated cloudinit datasource under {{ cloudinit.data_source_path }}/runcmd