### PR TITLE
fix(k3s): remove inclusion envsubst binary in k3s test

### DIFF
--- a/.github/workflows/test-k3s.yaml
+++ b/.github/workflows/test-k3s.yaml
@@ -26,7 +26,7 @@ on:
   - cron: '0 10 */30 * *'
 
 env:
-  non_workflow_dispatch_log_verbosity: '1'
+  non_workflow_dispatch_log_verbosity: '0'
   molecule_vars_file: /tmp/molecule_vars.yaml
 
 concurrency:
@@ -57,11 +57,6 @@ jobs:
         python-version: '3.12'
         cache: 'poetry'
 
-    - name: Set up go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
-      with:
-        go-version: 'stable'
-
     - name: Install python requirements
       run: |
         poetry --version
@@ -74,10 +69,6 @@ jobs:
 
         # install collection dependencies w/ --force to ensure that replaced from local repository
         poetry run ansible-galaxy collection install --force ./packages/
-
-    - name: Build envsubst binary
-      run: |
-        go install github.com/drone/envsubst/cmd/envsubst@latest
 
     - name: Install sysbox
       run: |

--- a/k3s/molecule/default/molecule.yml
+++ b/k3s/molecule/default/molecule.yml
@@ -17,8 +17,6 @@ platforms:
   - name: k3s-cluster
   networks:
   - name: k3s-cluster
-  volumes:
-  - ~/go/bin/envsubst:/usr/local/bin/envsubst
   command: /usr/sbin/init
   runtime: sysbox-runc
   user: root
@@ -32,8 +30,6 @@ platforms:
   - name: k3s-cluster
   networks:
   - name: k3s-cluster
-  volumes:
-  - ~/go/bin/envsubst:/usr/local/bin/envsubst
   command: /usr/sbin/init
   runtime: sysbox-runc
   user: root


### PR DESCRIPTION
- It's no longer used within the test.
- flux cli now has envsubst baked into it as a command if we ever need it